### PR TITLE
Workaround tsc errors

### DIFF
--- a/test/decorators/ConfigClass.spec.ts
+++ b/test/decorators/ConfigClass.spec.ts
@@ -166,7 +166,7 @@ describe('ConfigClass', () => {
     chai.expect((c.__state as any).main.value[0].__state.a.tags.name).to.deep.equal(['main name']);
     chai.expect((wc.__state as any).main.value[0].__state.a.tags.name).to.deep.equal('web name');
     chai.expect((wc.__state as any).main.value[0].__state.a.tags.extraTag).to.deep.equal('test');
-    chai.expect((wc.clone().__state as any).main.value[0].__state.a.tags.name).to.deep.equal('web name');
+    chai.expect(((wc.clone() as any).__state as any).main.value[0].__state.a.tags.name).to.deep.equal('web name');
   });
 
   it('should JSON skip default values should not change value', () => {

--- a/test/decorators/WebConfigClass.spec.ts
+++ b/test/decorators/WebConfigClass.spec.ts
@@ -211,7 +211,7 @@ describe('WebConfigClass', () => {
       chai.expect((c.sub.arr[1] as any).toJSON({attachState: true})).to.deep.equal({
         __state: {num: {}, num2: {}}, num2: 10
       });
-      chai.expect((c.clone<C>().sub.arr[1] as any).toJSON({attachState: true})).to.deep.equal({
+      chai.expect(((c as any).clone().sub.arr[1] as any).toJSON({attachState: true})).to.deep.equal({
         __state: {num: {}, num2: {}}, num2: 10
       });
 


### PR DESCRIPTION
I had hit these errors:

```
test/decorators/ConfigClass.spec.ts:169:29 - error TS2339: Property '__state' does not exist on type 'IConfigClassBase<unknown>'.

169     chai.expect((wc.clone().__state as any).main.value[0].__state.a.tags.name).to.deep.equal('web name');
                                ~~~~~~~

test/decorators/WebConfigClass.spec.ts:214:22 - error TS2339: Property 'clone' does not exist on type 'C & IConfigClassBase<unknown>'.

214       chai.expect((c.clone<C>().sub.arr[1] as any).toJSON({attachState: true})).to.deep.equal({
                         ~~~~~
```

It's possible that I'm running an old version of npm or typescript or something, though.

Also, my fixes seem like cheats - I'm just adding `as any` to silence the warnings.  Perhaps the right fix is a change to the code so typescript can correctly tell that these properties do exist on these types?